### PR TITLE
Convert Datadog rate metrics to OTel counters in the receiver, and back in the exporter

### DIFF
--- a/receiver/chqdatadogreceiver/metricsv2.go
+++ b/receiver/chqdatadogreceiver/metricsv2.go
@@ -241,13 +241,15 @@ func (ddr *datadogReceiver) convertMetricV2(m pmetric.Metrics, v2 *ddpb.MetricPa
 			populateDatapoint(&gdp, point.Timestamp*1000, &v2.Interval, point.Value)
 		}
 	case ddpb.MetricPayload_RATE:
-		g := metric.SetEmptyGauge()
+		c := metric.SetEmptySum()
+		c.SetIsMonotonic(false)
+		c.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 		for _, point := range v2.Points {
-			gdp := g.DataPoints().AppendEmpty()
-			lAttr.CopyTo(gdp.Attributes())
-			gdp.Attributes().PutBool("dd.israte", true)
-			gdp.Attributes().PutInt("dd.rateInterval", v2.Interval)
-			populateDatapoint(&gdp, point.Timestamp*1000, &v2.Interval, point.Value)
+			cdp := c.DataPoints().AppendEmpty()
+			lAttr.CopyTo(cdp.Attributes())
+			cdp.Attributes().PutBool("dd.israte", true)
+			cdp.Attributes().PutInt("dd.rateInterval", v2.Interval)
+			populateDatapoint(&cdp, point.Timestamp*1000, &v2.Interval, point.Value*float64(v2.Interval))
 		}
 	case ddpb.MetricPayload_COUNT:
 		c := metric.SetEmptySum()


### PR DESCRIPTION
Converts the incoming rate/sec value to a count by multiplying its value by the interval (10sec by default), and back to a rate value in the exporter on the way to Datadog. 

/cc @ruchirj 