### PR TITLE
Fix rate -> count conversion for Datadog v1 metrics

### DIFF
--- a/receiver/chqdatadogreceiver/metricsv1.go
+++ b/receiver/chqdatadogreceiver/metricsv1.go
@@ -129,7 +129,7 @@ func (ddr *datadogReceiver) convertMetricV1(v1 SeriesV1) (pmetric.Metrics, error
 		for _, point := range v1.Points {
 			dp := c.DataPoints().AppendEmpty()
 			lAttr.CopyTo(dp.Attributes())
-			populateDatapoint(&dp, point.V1*1000, point.V2/float64(interval))
+			populateDatapoint(&dp, point.V1*1000, point.V2*float64(interval))
 			dp.Attributes().PutInt("_dd.rateInterval", interval)
 		}
 	}


### PR DESCRIPTION
Makes this consistent with the right behavior we're doing for v2 metrics already