### PR TITLE
improve metric name to lowercase by handling CamelCase

### DIFF
--- a/exporter/chqs3exporter/internal/translation/table/namemap_test.go
+++ b/exporter/chqs3exporter/internal/translation/table/namemap_test.go
@@ -51,9 +51,61 @@ func TestSanitizeAttribute(t *testing.T) {
 			"Downcases",
 			"downcases",
 		},
+		{
+			"UPPERCASE",
+			"uppercase",
+		},
+		{
+			"AWSCloudWatch.max",
+			"aws_cloud_watch.max",
+		},
 	}
 
 	for _, test := range tests {
 		assert.Equal(t, test.expected, sanitizeAttribute(test.input))
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			"helloWorld",
+			"hello_world",
+		},
+		{
+			"camelCase",
+			"camel_case",
+		},
+		{
+			"snake_case",
+			"snake_case",
+		},
+		{
+			"AWSCloudWatch",
+			"aws_cloud_watch",
+		},
+		{
+			"kebab-case",
+			"kebab-case",
+		},
+		{
+			"UPPER_CASE",
+			"upper_case",
+		},
+		{
+			"leadingUnderscore",
+			"leading_underscore",
+		},
+		{
+			"123Numbers456",
+			"123_numbers456",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, toSnakeCase(test.input))
 	}
 }


### PR DESCRIPTION
Improve the metric name and tag name conversion to make it more human friendly.

Now, all tags are lowercased, but they are converted from `SnakeCase` to `snake_case` as well.  This is done per-label, where a label is anything between `.` markers.