### PR TITLE
Update `resource.service.name` derivation logic for Datadog metrics

### DIFF
--- a/receiver/chqdatadogreceiver/metricsv2.go
+++ b/receiver/chqdatadogreceiver/metricsv2.go
@@ -186,7 +186,7 @@ func ensureServiceName(rAttr pcommon.Map, kv map[string]string) {
 	if _, ok := rAttr.Get("service.name"); ok {
 		return
 	}
-	searchPath := []string{"kube_deployment", "kube_stateful_set", "kube_daemon_set", "container_name", "short_image"}
+	searchPath := []string{"service", "kube_deployment", "kube_stateful_set", "kube_daemon_set", "short_image", "container_name"}
 	for _, path := range searchPath {
 		if v, ok := kv[path]; ok {
 			rAttr.PutStr("service.name", v)


### PR DESCRIPTION
- Use the `service` tag, if it's present on the incoming DD payload
- Make `short_image` higher precendence than `container_name` since the latter can include a hash that changes on every new container creation

This will prevent us from creating 800+ services (and growing!) for Fleak, etc. 😄 

<img width="552" alt="image" src="https://github.com/user-attachments/assets/216138d1-381b-4818-8103-dd2b4ca1a7cd">
