### PR TITLE
Remove x-cardinalhq-collector-id and x-cardinalhq-environment headers

### DIFF
--- a/exporter/chqentitygraphexporter/README.md
+++ b/exporter/chqentitygraphexporter/README.md
@@ -29,7 +29,6 @@ exporters:
       endpoint: "https://stats-receiver.global.aws.cardinalhq.io"
       headers:
         x-cardinalhq-api-key: ${env:CARDINAL_API_KEY}
-        x-cardinalhq-collector-id: ${env:CARDINAL_COLLECTOR_ID}
 ```
 
 When sending this data to Cardinal for Chip AI, these values can be obtained through the

--- a/exporter/chqk8sentitygraphexporter/README.md
+++ b/exporter/chqk8sentitygraphexporter/README.md
@@ -29,7 +29,6 @@ exporters:
       endpoint: "https://stats-receiver.global.aws.cardinalhq.io"
       headers:
         x-cardinalhq-api-key: ${env:CARDINAL_API_KEY}
-        x-cardinalhq-collector-id: ${env:CARDINAL_COLLECTOR_ID}
 ```
 
 When sending this data to Cardinal for Chip AI, these values can be obtained through the

--- a/extension/chqauthextension/clientauth.go
+++ b/extension/chqauthextension/clientauth.go
@@ -17,7 +17,6 @@ package chqauthextension
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -31,7 +30,6 @@ type chqClientAuth struct {
 
 	config   *ClientAuth
 	insecure bool
-	env      map[string]string
 }
 
 var (
@@ -44,16 +42,13 @@ func newClientAuthExtension(cfg *Config, _ extension.Settings) (*chqClientAuth, 
 	chq := chqClientAuth{
 		config:   cfg.ClientAuth,
 		insecure: cfg.ClientAuth.Insecure,
-		env:      cfg.ClientAuth.Environment,
 	}
 	return &chq, nil
 }
 
 type chqRoundTripper struct {
-	base        http.RoundTripper
-	apiKey      string
-	collectorID string
-	env         map[string]string
+	base   http.RoundTripper
+	apiKey string
 }
 
 func (chq *chqClientAuth) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
@@ -61,20 +56,14 @@ func (chq *chqClientAuth) RoundTripper(base http.RoundTripper) (http.RoundTrippe
 		return base, nil
 	}
 	return &chqRoundTripper{
-		base:        base,
-		apiKey:      chq.config.APIKey,
-		collectorID: chq.config.CollectorID,
-		env:         chq.env,
+		base:   base,
+		apiKey: chq.config.APIKey,
 	}, nil
 }
 
 func (c *chqRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	newReq := req.Clone(req.Context())
 	newReq.Header.Set(apiKeyHeader, c.apiKey)
-	if c.collectorID != "" {
-		newReq.Header.Set(collectorIDHeader, c.collectorID)
-	}
-	newReq.Header.Set(envKeyHeader, encodeEnv(c.env))
 	return c.base.RoundTrip(newReq)
 }
 
@@ -87,24 +76,10 @@ func (chq *chqClientAuth) PerRPCCredentials() (creds.PerRPCCredentials, error) {
 	metadata := map[string]string{
 		apiKeyHeader: chq.config.APIKey,
 	}
-	if chq.config.CollectorID != "" {
-		metadata[collectorIDHeader] = chq.config.CollectorID
-	}
-	if len(chq.env) > 0 {
-		metadata[envKeyHeader] = encodeEnv(chq.env)
-	}
 	return &chqPerRPCAuth{
 		metadata: metadata,
 		insecure: chq.config.Insecure,
 	}, nil
-}
-
-func encodeEnv(env map[string]string) string {
-	var items []string
-	for k, v := range env {
-		items = append(items, k+"="+v)
-	}
-	return strings.Join(items, ";")
 }
 
 func (c *chqPerRPCAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {

--- a/extension/chqauthextension/clientauth_test.go
+++ b/extension/chqauthextension/clientauth_test.go
@@ -13,25 +13,3 @@
 // limitations under the License.
 
 package chqauthextension
-
-import (
-	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-func TestEncodeEnv(t *testing.T) {
-	env := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
-	}
-
-	expected := "key1=value1;key2=value2;key3=value3"
-	result := encodeEnv(env)
-
-	retSplit := strings.Split(result, ";")
-	expSplit := strings.Split(expected, ";")
-	assert.ElementsMatch(t, retSplit, expSplit)
-}

--- a/extension/chqauthextension/config.go
+++ b/extension/chqauthextension/config.go
@@ -29,10 +29,8 @@ type ServerAuth struct {
 }
 
 type ClientAuth struct {
-	APIKey      string            `mapstructure:"api_key"`
-	CollectorID string            `mapstructure:"collector_id"`
-	Insecure    bool              `mapstructure:"insecure"`
-	Environment map[string]string `mapstructure:"environment"`
+	APIKey   string `mapstructure:"api_key"`
+	Insecure bool   `mapstructure:"insecure"`
 }
 
 type Config struct {
@@ -50,8 +48,6 @@ var (
 	errNoAuthConfig        = errors.New("one of client_auth.api_key or server_auth.endpoint must be set")
 	errDuplicateAuthConfig = errors.New("only one of client_auth.api_key or server_auth.endpoint can be set")
 	errNoClientAPIKey      = errors.New("client_auth.api_key must be set")
-	errBadEnvironmentKey   = errors.New("environment key contains invalid characters: only lowercase letters and _ are allowed")
-	errBadEnvironmentValue = errors.New("environment value contains invalid characters: only alphanumeric characters and _-.@:/, are allowed")
 )
 
 var defaultHeaders = []string{
@@ -83,15 +79,6 @@ func (cfg *ClientAuth) Validate() error {
 		return errNoClientAPIKey
 	}
 
-	for k, v := range cfg.Environment {
-		if sanitizeKey(k) != k {
-			return errBadEnvironmentKey
-		}
-		if sanitizeValue(v) != v {
-			return errBadEnvironmentValue
-		}
-	}
-
 	return nil
 }
 
@@ -110,27 +97,4 @@ func (cfg *ServerAuth) Validate() error {
 		cfg.Headers = defaultHeaders
 	}
 	return nil
-}
-
-// allow only lowercase letterrs and _
-func sanitizeKey(key string) string {
-	for _, c := range key {
-		if (c < 'a' || c > 'z') && c != '_' {
-			return ""
-		}
-	}
-	return key
-}
-
-// allow uppercase and lowercase letters, numbers, and _-.@:/,
-func sanitizeValue(value string) string {
-	for _, c := range value {
-		if (c < 'a' || c > 'z') &&
-			(c < 'A' || c > 'Z') &&
-			(c < '0' || c > '9') &&
-			c != '_' && c != '-' && c != '.' && c != '@' && c != ':' && c != '/' && c != ',' {
-			return ""
-		}
-	}
-	return value
 }

--- a/extension/chqauthextension/config_test.go
+++ b/extension/chqauthextension/config_test.go
@@ -87,106 +87,6 @@ func TestServerAuth_Validate(t *testing.T) {
 		})
 	}
 }
-func TestSanitizeKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		key      string
-		expected string
-	}{
-		{
-			"valid key",
-			"abc",
-			"abc",
-		},
-		{
-			"incalid due to upppercase",
-			"AbC",
-			"",
-		},
-		{
-			"invalid due to numbers",
-			"abc123",
-			"",
-		},
-		{
-			"invalid key with uppercase",
-			"AbC123",
-			"",
-		},
-		{
-			"key with special characters",
-			"abc_123",
-			"",
-		},
-		{
-			"key with spaces",
-			"abc 123",
-			"",
-		},
-		{
-			"key_with_symbols",
-			"abc_foo",
-			"abc_foo",
-		},
-		{
-			"empty key",
-			"",
-			"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeKey(tt.key)
-			if result != tt.expected {
-				t.Errorf("Expected sanitized key %s, got %s", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestSanitizeValue(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    string
-		expected string
-	}{
-		{
-			"valid value",
-			"abc",
-			"abc",
-		},
-		{
-			"value with symbols",
-			"abc_-./@:,123",
-			"abc_-./@:,123",
-		},
-		{
-			"valid value with spaces",
-			"abc 123",
-			"",
-		},
-		{
-			"invalid value with non-printable characters",
-			"abc\x00",
-			"",
-		},
-		{
-			"empty value",
-			"",
-			"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeValue(tt.value)
-			if result != tt.expected {
-				t.Errorf("Expected sanitized value %s, got %s", tt.expected, result)
-			}
-		})
-	}
-}
 
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
@@ -199,20 +99,12 @@ func TestConfig_Validate(t *testing.T) {
 			"valid client auth",
 			&Config{
 				ClientAuth: &ClientAuth{
-					APIKey:      "key",
-					CollectorID: "collector1",
-					Environment: map[string]string{
-						"markus": "value1",
-					},
+					APIKey: "key",
 				},
 			},
 			&Config{
 				ClientAuth: &ClientAuth{
-					APIKey:      "key",
-					CollectorID: "collector1",
-					Environment: map[string]string{
-						"markus": "value1",
-					},
+					APIKey: "key",
 				},
 			},
 			nil,
@@ -227,8 +119,7 @@ func TestConfig_Validate(t *testing.T) {
 			"both auth config",
 			&Config{
 				ClientAuth: &ClientAuth{
-					APIKey:      "key",
-					CollectorID: "collector1",
+					APIKey: "key",
 				},
 				ServerAuth: &ServerAuth{
 					ClientConfig: confighttp.ClientConfig{
@@ -238,8 +129,7 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			&Config{
 				ClientAuth: &ClientAuth{
-					APIKey:      "key",
-					CollectorID: "collector1",
+					APIKey: "key",
 				},
 				ServerAuth: &ServerAuth{
 					ClientConfig: confighttp.ClientConfig{
@@ -260,12 +150,6 @@ func TestConfig_Validate(t *testing.T) {
 			if tt.config.ClientAuth != nil {
 				if tt.config.ClientAuth.APIKey != tt.expected.ClientAuth.APIKey {
 					t.Errorf("Expected APIKey %s, got %s", tt.expected.ClientAuth.APIKey, tt.config.ClientAuth.APIKey)
-				}
-				if tt.config.ClientAuth.CollectorID != tt.expected.ClientAuth.CollectorID {
-					t.Errorf("Expected CollectorID %s, got %s", tt.expected.ClientAuth.CollectorID, tt.config.ClientAuth.CollectorID)
-				}
-				if len(tt.config.ClientAuth.Environment) != len(tt.expected.ClientAuth.Environment) {
-					t.Errorf("Expected Environment %v, got %v", tt.expected.ClientAuth.Environment, tt.config.ClientAuth.Environment)
 				}
 			}
 			if tt.config.ServerAuth != nil {
@@ -293,18 +177,10 @@ func TestClientAuth_Validate(t *testing.T) {
 		{
 			"valid",
 			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus": "value1",
-				},
+				APIKey: "key",
 			},
 			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus": "value1",
-				},
+				APIKey: "key",
 			},
 			nil,
 		},
@@ -318,42 +194,6 @@ func TestClientAuth_Validate(t *testing.T) {
 			},
 			errNoClientAPIKey,
 		},
-		{
-			"invalid environment key",
-			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus1": "value1",
-				},
-			},
-			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus1": "value1",
-				},
-			},
-			errBadEnvironmentKey,
-		},
-		{
-			"invalid environment value",
-			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus": "value\x00",
-				},
-			},
-			&ClientAuth{
-				APIKey:      "key",
-				CollectorID: "collector1",
-				Environment: map[string]string{
-					"markus": "value\x00",
-				},
-			},
-			errBadEnvironmentValue,
-		},
 	}
 
 	for _, tt := range tests {
@@ -364,12 +204,6 @@ func TestClientAuth_Validate(t *testing.T) {
 			}
 			if tt.config.APIKey != tt.expected.APIKey {
 				t.Errorf("Expected APIKey %s, got %s", tt.expected.APIKey, tt.config.APIKey)
-			}
-			if tt.config.CollectorID != tt.expected.CollectorID {
-				t.Errorf("Expected CollectorID %s, got %s", tt.expected.CollectorID, tt.config.CollectorID)
-			}
-			if len(tt.config.Environment) != len(tt.expected.Environment) {
-				t.Errorf("Expected Environment %v, got %v", tt.expected.Environment, tt.config.Environment)
 			}
 		})
 	}

--- a/extension/chqauthextension/extension.go
+++ b/extension/chqauthextension/extension.go
@@ -15,7 +15,5 @@
 package chqauthextension
 
 const (
-	apiKeyHeader      = "x-cardinalhq-api-key"
-	collectorIDHeader = "x-cardinalhq-collector-id"
-	envKeyHeader      = "x-cardinalhq-environment"
+	apiKeyHeader = "x-cardinalhq-api-key"
 )

--- a/extension/chqauthextension/internal/metadata/README.md
+++ b/extension/chqauthextension/internal/metadata/README.md
@@ -7,8 +7,7 @@ not guaranteed outside the Cardinal use case.
 
 ## Client Auth
 
-Client authentication is configured via an API key and some optional environmental
-settings to pass additional context to the server.  This extension otherwise
+Client authentication is configured via an API key.  This extension otherwise
 acts as a standard authentication extension coupled with a header setting
 extension.
 
@@ -16,11 +15,10 @@ extension.
 
 * `api_key`: a string representing the API key.
 * `insecure`: ignore TLS certificate errors.
-* `environment`: a `map[string]string` that allows setting arbitrary key/value pairs for use with the Cardinal SaaS service and other Cardinal endpoints.  The only required one for most of the Cardinal API calls is `collector_id=name` to indicate which specific collector group is making the API call.
 
 ## Server Auth
 
-Server authentication is made by calling an endpoint to validate and obtain information based on the incoming API key and environment.
+Server authentication is made by calling an endpoint to validate and obtain information based on the incoming API key.
 There is a cache which is always configured, and defaults to 10 minutes.
 The API calls made are documented in `serverauth.go`.
 
@@ -31,7 +29,4 @@ extensions:
   chqauth:
     client_auth:
       api_key: "${env:CARDINALHQ_API_KEY}"
-      environment:
-        collector_id: "aws-test-us-east-2"
-        customer_id: "e7b8f8e2-4b2d-4f8b-8a1e-1d4f8e2b4b2d"
 ```

--- a/extension/chqauthextension/serverauth.go
+++ b/extension/chqauthextension/serverauth.go
@@ -107,15 +107,11 @@ func (chq *chqServerAuth) Authenticate(ctx context.Context, headers map[string][
 	if auth == "" {
 		return ctx, errNoAuthHeader
 	}
-	collectorID := getCollectorFromHeaders(headers)
 
-	envkeys := getEnvFromHeaders(headers)
-
-	authData, err := chq.authenticateAPIKey(ctx, auth, collectorID)
+	authData, err := chq.authenticateAPIKey(ctx, auth)
 	if err != nil {
 		return ctx, err
 	}
-	authData.environment = envkeys
 
 	cl := client.FromContext(ctx)
 	cl.Auth = authData
@@ -123,17 +119,15 @@ func (chq *chqServerAuth) Authenticate(ctx context.Context, headers map[string][
 }
 
 type validateResponse struct {
-	CustomerID    string `json:"customer_id"`
-	CustomerName  string `json:"customer_name"`
-	CollectorID   string `json:"collector_id"`
-	CollectorName string `json:"collector_name"`
-	Valid         bool   `json:"valid"`
+	CustomerID   string `json:"customer_id"`
+	CustomerName string `json:"customer_name"`
+	Valid        bool   `json:"valid"`
 }
 
-func (chq *chqServerAuth) getcache(cacheKey string) (*authData, bool) {
+func (chq *chqServerAuth) getcache(apiKey string) (*authData, bool) {
 	chq.cacheLock.Lock()
 	defer chq.cacheLock.Unlock()
-	ad, ok := chq.lookupCache[cacheKey]
+	ad, ok := chq.lookupCache[apiKey]
 	if !ok {
 		attrs := metric.WithAttributes(attribute.String("cache", "miss"))
 		chq.authCacheLookups.Add(context.Background(), 1, attrs)
@@ -142,7 +136,7 @@ func (chq *chqServerAuth) getcache(cacheKey string) (*authData, bool) {
 	if ad.expiry.Before(time.Now()) {
 		attrs := metric.WithAttributes(attribute.String("cache", "expired"))
 		chq.authCacheLookups.Add(context.Background(), 1, attrs)
-		delete(chq.lookupCache, cacheKey)
+		delete(chq.lookupCache, apiKey)
 		return ad, true
 	}
 	attrs := metric.WithAttributes(attribute.String("cache", "hit"))
@@ -150,19 +144,15 @@ func (chq *chqServerAuth) getcache(cacheKey string) (*authData, bool) {
 	return ad, false
 }
 
-func getCacheKey(apiKey, collectorID string) string {
-	return apiKey + ":" + collectorID
-}
-
 func (chq *chqServerAuth) setcache(ad *authData) {
 	chq.authCacheAdds.Add(context.Background(), 1)
 	chq.cacheLock.Lock()
 	defer chq.cacheLock.Unlock()
-	chq.lookupCache[getCacheKey(ad.apiKey, ad.collectorID)] = ad
+	chq.lookupCache[ad.apiKey] = ad
 }
 
-func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey, collectorID string) (*authData, error) {
-	cached, expired := chq.getcache(getCacheKey(apiKey, collectorID))
+func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey string) (*authData, error) {
+	cached, expired := chq.getcache(apiKey)
 	if cached != nil && !expired {
 		if !cached.valid {
 			return nil, errDenied
@@ -170,14 +160,13 @@ func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey, collec
 		return cached, nil
 	}
 
-	ad, err := chq.callValidateAPI(ctx, apiKey, collectorID)
+	ad, err := chq.callValidateAPI(ctx, apiKey)
 	if err != nil {
 		if errors.Is(err, errDenied) {
 			ad = &authData{
-				apiKey:      apiKey,
-				collectorID: collectorID,
-				valid:       false,
-				expiry:      time.Now().Add(chq.config.ServerAuth.CacheTTLInvalid),
+				apiKey: apiKey,
+				valid:  false,
+				expiry: time.Now().Add(chq.config.ServerAuth.CacheTTLInvalid),
 			}
 			chq.setcache(ad)
 		}
@@ -194,15 +183,12 @@ func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey, collec
 	return ad, nil
 }
 
-func (chq *chqServerAuth) callValidateAPI(ctx context.Context, apiKey, collectorID string) (*authData, error) {
+func (chq *chqServerAuth) callValidateAPI(ctx context.Context, apiKey string) (*authData, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, chq.config.ServerAuth.Endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set(apiKeyHeader, apiKey)
-	if collectorID != "" {
-		req.Header.Set(collectorIDHeader, collectorID)
-	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := chq.httpClient.Do(req)
@@ -224,12 +210,10 @@ func (chq *chqServerAuth) callValidateAPI(ctx context.Context, apiKey, collector
 	}
 
 	return &authData{
-		apiKey:        apiKey,
-		customerID:    validateResp.CustomerID,
-		customerName:  validateResp.CustomerName,
-		collectorID:   validateResp.CollectorID,
-		collectorName: validateResp.CollectorName,
-		valid:         validateResp.Valid,
+		apiKey:       apiKey,
+		customerID:   validateResp.CustomerID,
+		customerName: validateResp.CustomerName,
+		valid:        validateResp.Valid,
 	}, nil
 }
 
@@ -244,45 +228,12 @@ func getAuthHeader(targets []string, h map[string][]string) string {
 	return ""
 }
 
-func getCollectorFromHeaders(h map[string][]string) string {
-	for k, v := range h {
-		if strings.EqualFold(k, collectorIDHeader) {
-			return v[0]
-		}
-	}
-	return ""
-}
-
-func getEnvFromHeaders(h map[string][]string) map[string]string {
-	for k, v := range h {
-		if strings.EqualFold(k, envKeyHeader) {
-			return parseEnv(v[0])
-		}
-	}
-	return map[string]string{}
-}
-
-func parseEnv(env string) map[string]string {
-	items := strings.Split(env, ";")
-	envMap := make(map[string]string)
-	for _, item := range items {
-		parts := strings.Split(item, "=")
-		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
-		}
-	}
-	return envMap
-}
-
 type authData struct {
-	apiKey        string
-	environment   map[string]string
-	customerID    string
-	customerName  string
-	collectorID   string
-	collectorName string
-	valid         bool
-	expiry        time.Time
+	apiKey       string
+	customerID   string
+	customerName string
+	valid        bool
+	expiry       time.Time
 }
 
 var _ client.AuthData = (*authData)(nil)
@@ -291,16 +242,10 @@ func (a *authData) GetAttribute(name string) any {
 	switch name {
 	case "api_key":
 		return a.apiKey
-	case "environment":
-		return a.environment
 	case "customer_id":
 		return a.customerID
 	case "customer_name":
 		return a.customerName
-	case "collector_id":
-		return a.collectorID
-	case "collector_name":
-		return a.collectorName
 	case "valid":
 		return a.valid
 	default:
@@ -309,5 +254,5 @@ func (a *authData) GetAttribute(name string) any {
 }
 
 func (a *authData) GetAttributeNames() []string {
-	return []string{"api_key", "environment", "customer_id", "customer_name", "collector_id", "collector_name", "valid"}
+	return []string{"api_key", "customer_id", "customer_name", "valid"}
 }

--- a/extension/chqauthextension/serverauth_test.go
+++ b/extension/chqauthextension/serverauth_test.go
@@ -111,16 +111,14 @@ func TestSetCache(t *testing.T) {
 	}
 
 	chq.setcache(ad)
-	assert.Equal(t, ad, chq.lookupCache[getCacheKey(ad.apiKey, ad.collectorID)])
+	assert.Equal(t, ad, chq.lookupCache[ad.apiKey])
 }
 
 func TestGetAttribute(t *testing.T) {
 	ad := &authData{
 		apiKey:       "key1",
-		environment:  map[string]string{"env1": "value1"},
 		customerID:   "client1",
 		customerName: "John Doe",
-		collectorID:  "collector1",
 		valid:        true,
 		expiry:       time.Now().Add(time.Hour),
 	}
@@ -134,20 +132,12 @@ func TestGetAttribute(t *testing.T) {
 			"key1",
 		},
 		{
-			"environment",
-			map[string]string{"env1": "value1"},
-		},
-		{
 			"customer_id",
 			"client1",
 		},
 		{
 			"customer_name",
 			"John Doe",
-		},
-		{
-			"collector_id",
-			"collector1",
 		},
 		{
 			"valid",
@@ -168,7 +158,7 @@ func TestGetAttribute(t *testing.T) {
 
 func TestGetAttributeNames(t *testing.T) {
 	ad := &authData{}
-	expected := []string{"api_key", "environment", "customer_id", "customer_name", "collector_id", "collector_name", "valid"}
+	expected := []string{"api_key", "customer_id", "customer_name", "valid"}
 	names := ad.GetAttributeNames()
 	assert.ElementsMatch(t, expected, names)
 }
@@ -182,13 +172,13 @@ func TestGetAuthHeader(t *testing.T) {
 	}{
 		{
 			"no header",
-			[]string{apiKeyHeader, collectorIDHeader, envKeyHeader},
+			[]string{apiKeyHeader},
 			map[string][]string{},
 			"",
 		},
 		{
 			"header not found",
-			[]string{apiKeyHeader, collectorIDHeader, envKeyHeader},
+			[]string{apiKeyHeader},
 			map[string][]string{
 				"Content-Type": {"application/json"},
 			},
@@ -196,7 +186,7 @@ func TestGetAuthHeader(t *testing.T) {
 		},
 		{
 			"header found",
-			[]string{apiKeyHeader, collectorIDHeader, envKeyHeader},
+			[]string{apiKeyHeader},
 			map[string][]string{
 				"x-cardinalhq-api-key": {"my-api-key"},
 				"Content-Type":         {"application/json"},
@@ -205,7 +195,7 @@ func TestGetAuthHeader(t *testing.T) {
 		},
 		{
 			"case insensitive",
-			[]string{apiKeyHeader, collectorIDHeader, envKeyHeader},
+			[]string{apiKeyHeader},
 			map[string][]string{
 				"X-CARDINALHQ-API-KEY": {"my-api-key"},
 				"Content-Type":         {"application/json"},
@@ -218,58 +208,6 @@ func TestGetAuthHeader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			authHeader := getAuthHeader(tt.targets, tt.headers)
 			assert.Equal(t, tt.expected, authHeader)
-		})
-	}
-}
-
-func TestGetEnvFromHeaders(t *testing.T) {
-	tests := []struct {
-		name     string
-		headers  map[string][]string
-		expected map[string]string
-	}{
-		{
-			"no headers",
-			map[string][]string{},
-			map[string]string{},
-		},
-		{
-			"no env headers",
-			map[string][]string{
-				"Content-Type": {"application/json"},
-			},
-			map[string]string{},
-		},
-		{
-			"single env header",
-			map[string][]string{
-				"x-cardinalhq-environment": {"bar=bax"},
-				"Content-Type":             {"application/json"},
-			},
-			map[string]string{"bar": "bax"},
-		},
-		{
-			"multiple env headers",
-			map[string][]string{
-				"x-cardinalhq-environment": {"foo=bar;baz=qux"},
-				"Content-Type":             {"application/json"},
-			},
-			map[string]string{"foo": "bar", "baz": "qux"},
-		},
-		{
-			"case insensitive",
-			map[string][]string{
-				"X-CARDINALHQ-ENVIRONmenT": {"foo=bar"},
-				"Content-Type":             {"application/json"},
-			},
-			map[string]string{"foo": "bar"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := getEnvFromHeaders(tt.headers)
-			assert.Equal(t, tt.expected, env)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Remove `x-cardinalhq-collector-id` header: no longer sent by client auth or extracted by server auth
- Remove `x-cardinalhq-environment` header: drop `Environment` config field, `encodeEnv`/`parseEnv` helpers, and `sanitizeKey`/`sanitizeValue` validators
- Simplify `authData` to only carry `api_key`, `customer_id`, `customer_name`, and `valid`
- Simplify cache key from `apiKey:collectorID` to just `apiKey`
- Update READMEs for chqentitygraphexporter, chqk8sentitygraphexporter, and chqauthextension

## Test plan
- [x] `go test ./...` passes in `extension/chqauthextension`
- [x] `go vet ./...` clean
- [ ] Full `make check` in CI