### PR TITLE
chqauth: reject empty customer_id and fix revoked-key leak

### DIFF
--- a/extension/chqauthextension/serverauth.go
+++ b/extension/chqauthextension/serverauth.go
@@ -178,8 +178,12 @@ func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey string)
 		// Transient error (network, 5xx, parse): fall back to the last
 		// known cached entry if we have one, to preserve availability.
 		if cached != nil {
+			chq.logger.Warn("auth validator transient failure; serving expired cache entry",
+				zap.Error(err))
 			return cached, nil
 		}
+		chq.logger.Warn("auth validator transient failure; no cache available",
+			zap.Error(err))
 		return nil, err
 	}
 	ad.expiry = time.Now().Add(chq.config.ServerAuth.CacheTTLValid)
@@ -221,6 +225,11 @@ func (chq *chqServerAuth) callValidateAPI(ctx context.Context, apiKey string) (*
 	// tenant — resulting in data written to paths that lack a customer
 	// UUID segment.
 	if !validateResp.Valid || validateResp.CustomerID == "" {
+		if validateResp.Valid && validateResp.CustomerID == "" {
+			// Upstream contract violation: treated as a denial below, but
+			// log it distinctly so it doesn't masquerade as a normal revocation.
+			chq.logger.Error("auth validator returned valid=true with empty customer_id")
+		}
 		return nil, errDenied
 	}
 

--- a/extension/chqauthextension/serverauth.go
+++ b/extension/chqauthextension/serverauth.go
@@ -163,16 +163,20 @@ func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey string)
 	ad, err := chq.callValidateAPI(ctx, apiKey)
 	if err != nil {
 		if errors.Is(err, errDenied) {
-			ad = &authData{
+			chq.setcache(&authData{
 				apiKey: apiKey,
 				valid:  false,
 				expiry: time.Now().Add(chq.config.ServerAuth.CacheTTLInvalid),
-			}
-			chq.setcache(ad)
+			})
+			// A definitive denial must never fall back to a previously
+			// cached valid entry — that would let a revoked key keep
+			// authenticating as its former customer for one more TTL
+			// boundary crossing.
+			return nil, errDenied
 		}
 
-		// we have any error that isn't a definitive denial, we
-		// will return our perhaps expired cache entry
+		// Transient error (network, 5xx, parse): fall back to the last
+		// known cached entry if we have one, to preserve availability.
 		if cached != nil {
 			return cached, nil
 		}
@@ -207,6 +211,17 @@ func (chq *chqServerAuth) callValidateAPI(ctx context.Context, apiKey string) (*
 	var validateResp validateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&validateResp); err != nil {
 		return nil, err
+	}
+
+	// A response must positively assert validity and carry a non-empty
+	// customer_id before we treat it as an authenticated identity.
+	// Without this, a 200 OK carrying {"valid":true,"customer_id":""}
+	// (or {"valid":false,...}) would be accepted, cached under the
+	// valid-TTL, and every downstream request would flow with an empty
+	// tenant — resulting in data written to paths that lack a customer
+	// UUID segment.
+	if !validateResp.Valid || validateResp.CustomerID == "" {
+		return nil, errDenied
 	}
 
 	return &authData{

--- a/extension/chqauthextension/serverauth_test.go
+++ b/extension/chqauthextension/serverauth_test.go
@@ -15,10 +15,17 @@
 package chqauthextension
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
@@ -211,3 +218,156 @@ func TestGetAuthHeader(t *testing.T) {
 		})
 	}
 }
+// newchqWithServer returns a chqServerAuth wired against a mock validator
+// whose JSON body is controlled by the test. The returned cleanup closes
+// the server.
+func newchqWithServer(t *testing.T, handler http.HandlerFunc) (*chqServerAuth, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+
+	chq := newchq()
+	chq.config = &Config{ServerAuth: &ServerAuth{
+		ClientConfig:    confighttp.ClientConfig{Endpoint: srv.URL},
+		CacheTTLValid:   10 * time.Minute,
+		CacheTTLInvalid: 1 * time.Minute,
+		Headers:         []string{"x-cardinalhq-api-key"},
+	}}
+	chq.httpClient = srv.Client()
+	return chq, srv
+}
+
+func TestCallValidateAPI_RejectsInvalidOrEmptyCustomer(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantDenied bool
+	}{
+		{
+			name:       "valid=true with customer_id is accepted",
+			status:     http.StatusOK,
+			body:       `{"valid":true,"customer_id":"cust-1","customer_name":"n","collector_id":"col","collector_name":"cn"}`,
+			wantDenied: false,
+		},
+		{
+			name:       "valid=true but empty customer_id is denied",
+			status:     http.StatusOK,
+			body:       `{"valid":true,"customer_id":""}`,
+			wantDenied: true,
+		},
+		{
+			name:       "valid=false with 200 OK is denied",
+			status:     http.StatusOK,
+			body:       `{"valid":false,"customer_id":"cust-1"}`,
+			wantDenied: true,
+		},
+		{
+			name:       "valid=false and empty customer_id is denied",
+			status:     http.StatusOK,
+			body:       `{"valid":false,"customer_id":""}`,
+			wantDenied: true,
+		},
+		{
+			name:       "non-200 is denied",
+			status:     http.StatusForbidden,
+			body:       ``,
+			wantDenied: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			})
+			defer srv.Close()
+
+			ad, err := chq.callValidateAPI(context.Background(), "key")
+			if tt.wantDenied {
+				assert.Nil(t, ad)
+				assert.ErrorIs(t, err, errDenied)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, ad)
+			assert.Equal(t, "cust-1", ad.customerID)
+			assert.True(t, ad.valid)
+		})
+	}
+}
+
+func TestAuthenticateAPIKey_RevokedKeyDoesNotReturnStaleCache(t *testing.T) {
+	// This test guards against a regression where a revoked key, after
+	// the cached entry expired, would be re-authenticated as the old
+	// customer for one more TTL-boundary crossing.
+	var denyNext atomic.Bool
+	chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		if denyNext.Load() {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"valid":true,"customer_id":"cust-1","collector_id":"col"}`))
+	})
+	defer srv.Close()
+
+	// First call: populate cache with a valid entry.
+	ad, err := chq.authenticateAPIKey(context.Background(), "key")
+	require.NoError(t, err)
+	require.NotNil(t, ad)
+	assert.Equal(t, "cust-1", ad.customerID)
+
+	// Force the cached entry to look expired.
+	chq.cacheLock.Lock()
+	chq.lookupCache["key"].expiry = time.Now().Add(-time.Second)
+	chq.cacheLock.Unlock()
+
+	// Validator now denies the key (revoked).
+	denyNext.Store(true)
+
+	// Second call must return errDenied, not the previously valid authData.
+	ad2, err := chq.authenticateAPIKey(context.Background(), "key")
+	assert.Nil(t, ad2)
+	assert.True(t, errors.Is(err, errDenied), "expected errDenied, got %v", err)
+
+	// And the cache must now hold a valid=false entry so future calls
+	// within the invalid TTL are rejected without hitting the validator.
+	chq.cacheLock.Lock()
+	neg, ok := chq.lookupCache["key"]
+	chq.cacheLock.Unlock()
+	require.True(t, ok, "expected a negative cache entry after denial")
+	assert.False(t, neg.valid)
+}
+
+func TestAuthenticateAPIKey_TransientErrorFallsBackToCache(t *testing.T) {
+	// Verifies that genuine transient errors (network failures,
+	// parse errors) still allow the last-known cached entry to
+	// serve the request — the availability trade-off is retained.
+	// Note: the current implementation treats any non-200 as
+	// errDenied, so only connection-level failures exercise this
+	// branch.
+	chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"valid":true,"customer_id":"cust-1","collector_id":"col"}`))
+	})
+
+	ad, err := chq.authenticateAPIKey(context.Background(), "key")
+	require.NoError(t, err)
+	require.NotNil(t, ad)
+
+	// Expire the cached entry.
+	chq.cacheLock.Lock()
+	chq.lookupCache["key"].expiry = time.Now().Add(-time.Second)
+	chq.cacheLock.Unlock()
+
+	// Take the validator offline — httpClient.Do will surface a
+	// non-errDenied error, which must fall back to the cached entry.
+	srv.Close()
+
+	ad2, err := chq.authenticateAPIKey(context.Background(), "key")
+	require.NoError(t, err)
+	require.NotNil(t, ad2)
+	assert.Equal(t, "cust-1", ad2.customerID)
+}
+

--- a/extension/chqauthextension/serverauth_test.go
+++ b/extension/chqauthextension/serverauth_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/zap"
 )
 
 func newchq() *chqServerAuth {
@@ -35,6 +36,7 @@ func newchq() *chqServerAuth {
 	cam, _ := m.Int64Counter("auth_cache_adds")
 
 	chq := &chqServerAuth{
+		logger:           zap.NewNop(),
 		lookupCache:      make(map[string]*authData),
 		authCacheLookups: clm,
 		authCacheAdds:    cam,
@@ -297,12 +299,26 @@ func TestCallValidateAPI_RejectsInvalidOrEmptyCustomer(t *testing.T) {
 	}
 }
 
+// expireCacheEntry replaces the cached entry for the given key with a
+// copy whose expiry is in the past, without mutating a pointer that may
+// be shared with concurrent readers.
+func expireCacheEntry(t *testing.T, chq *chqServerAuth, key string) {
+	t.Helper()
+	chq.cacheLock.Lock()
+	entry := *chq.lookupCache[key]
+	chq.cacheLock.Unlock()
+	entry.expiry = time.Now().Add(-time.Second)
+	chq.setcache(&entry)
+}
+
 func TestAuthenticateAPIKey_RevokedKeyDoesNotReturnStaleCache(t *testing.T) {
 	// This test guards against a regression where a revoked key, after
 	// the cached entry expired, would be re-authenticated as the old
 	// customer for one more TTL-boundary crossing.
 	var denyNext atomic.Bool
+	var validatorHits atomic.Int32
 	chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		validatorHits.Add(1)
 		if denyNext.Load() {
 			w.WriteHeader(http.StatusForbidden)
 			return
@@ -318,10 +334,7 @@ func TestAuthenticateAPIKey_RevokedKeyDoesNotReturnStaleCache(t *testing.T) {
 	require.NotNil(t, ad)
 	assert.Equal(t, "cust-1", ad.customerID)
 
-	// Force the cached entry to look expired.
-	chq.cacheLock.Lock()
-	chq.lookupCache["key"].expiry = time.Now().Add(-time.Second)
-	chq.cacheLock.Unlock()
+	expireCacheEntry(t, chq, "key")
 
 	// Validator now denies the key (revoked).
 	denyNext.Store(true)
@@ -337,6 +350,36 @@ func TestAuthenticateAPIKey_RevokedKeyDoesNotReturnStaleCache(t *testing.T) {
 	neg, ok := chq.lookupCache["key"]
 	chq.cacheLock.Unlock()
 	require.True(t, ok, "expected a negative cache entry after denial")
+	assert.False(t, neg.valid)
+
+	hitsAfterDenial := validatorHits.Load()
+
+	// Third call within the invalid TTL must be served from the negative
+	// cache without another validator request.
+	ad3, err := chq.authenticateAPIKey(context.Background(), "key")
+	assert.Nil(t, ad3)
+	assert.True(t, errors.Is(err, errDenied), "expected errDenied from negative cache, got %v", err)
+	assert.Equal(t, hitsAfterDenial, validatorHits.Load(),
+		"negative cache must short-circuit the validator")
+}
+
+func TestAuthenticateAPIKey_EmptyCustomerIDIsDenied(t *testing.T) {
+	// End-to-end: a 200 OK response with an empty customer_id must be
+	// treated as a denial and cached under the invalid TTL.
+	chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"valid":true,"customer_id":""}`))
+	})
+	defer srv.Close()
+
+	ad, err := chq.authenticateAPIKey(context.Background(), "key")
+	assert.Nil(t, ad)
+	assert.True(t, errors.Is(err, errDenied), "expected errDenied, got %v", err)
+
+	chq.cacheLock.Lock()
+	neg, ok := chq.lookupCache["key"]
+	chq.cacheLock.Unlock()
+	require.True(t, ok, "expected a negative cache entry")
 	assert.False(t, neg.valid)
 }
 
@@ -356,10 +399,7 @@ func TestAuthenticateAPIKey_TransientErrorFallsBackToCache(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ad)
 
-	// Expire the cached entry.
-	chq.cacheLock.Lock()
-	chq.lookupCache["key"].expiry = time.Now().Add(-time.Second)
-	chq.cacheLock.Unlock()
+	expireCacheEntry(t, chq, "key")
 
 	// Take the validator offline — httpClient.Do will surface a
 	// non-errDenied error, which must fall back to the cached entry.


### PR DESCRIPTION
## Summary

Two bugs in the `chqauthextension` server-side auth path were allowing requests to pass as authenticated but with an empty `customer_id` — causing downstream processors (notably `resource/shared`'s `from_context: auth.customer_id`) to stamp `_cardinalhq.customer_id=""` on records, which in turn produced malformed S3 bucket prefixes like `otel-raw//<collector>` with no tenant UUID segment.

### Bug 1 — Empty-tenant acceptance (primary cause)

`callValidateAPI` checked only the HTTP status code. A 200 OK carrying `{"valid":true,"customer_id":""}` (or `{"valid":false,...}`) was accepted, cached under `CacheTTLValid` (10m default), and returned to callers with no error. Cache hits then short-circuited on `!cached.valid` only, so a `{valid:true, customer_id:""}` response leaked on every subsequent request for the full TTL.

Fix: `callValidateAPI` now returns `errDenied` unless `validateResp.Valid == true` AND `validateResp.CustomerID != ""`.

### Bug 2 — Revoked-key fallback to stale cache

`authenticateAPIKey` had:

```go
if err != nil {
    if errors.Is(err, errDenied) {
        // ... cache negative entry ...
    }
    // "we have any error that isn't a definitive denial, we
    //  will return our perhaps expired cache entry"
    if cached != nil {
        return cached, nil
    }
    ...
}
```

The comment's intent was to fall back only on transient errors, but the code ran for `errDenied` too. After a cached entry's TTL expired, a revoked key would: (a) cache a new valid=false entry, and (b) still return the old expired cached authData to the caller — authenticating the request as the former customer one more time per TTL boundary (more under concurrency).

Fix: on `errDenied`, cache the negative entry and return `errDenied`. Fall back to `cached` only for non-denial errors (network/parse failures).

## Test plan

- [x] New `TestCallValidateAPI_RejectsInvalidOrEmptyCustomer` covers five response shapes, including `{valid:true,customer_id:""}`, `{valid:false,...}`, and non-200.
- [x] New `TestAuthenticateAPIKey_RevokedKeyDoesNotReturnStaleCache` expires a cached entry, flips the validator to 403, and asserts `errDenied` plus a negative cache entry — no stale authData leaks.
- [x] New `TestAuthenticateAPIKey_TransientErrorFallsBackToCache` closes the validator mid-flight and asserts the cached entry is still returned for availability.
- [x] `go test ./extension/chqauthextension/...` passes.
- [x] `go vet ./extension/chqauthextension/...` clean.