### PR TITLE
chqauth: debug-log full invalid API keys

### DIFF
--- a/extension/chqauthextension/serverauth.go
+++ b/extension/chqauthextension/serverauth.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -51,7 +52,13 @@ type chqServerAuth struct {
 	httpClientSettings confighttp.ClientConfig
 	authCacheLookups   metric.Int64Counter
 	authCacheAdds      metric.Int64Counter
+
+	debugLogInvalidKeys   bool
+	invalidKeyLogLock     sync.Mutex
+	invalidKeyLogLastSeen map[string]time.Time
 }
+
+const invalidKeyLogInterval = 5 * time.Minute
 
 var (
 	_ extension.Extension  = (*chqServerAuth)(nil)
@@ -81,11 +88,13 @@ func (chq *chqServerAuth) setupServerTelemetry(params extension.Settings) error 
 
 func newServerAuthExtension(cfg *Config, params extension.Settings) (*chqServerAuth, error) {
 	chq := chqServerAuth{
-		config:             cfg,
-		httpClientSettings: cfg.ServerAuth.ClientConfig,
-		telemetrySettings:  params.TelemetrySettings,
-		logger:             params.Logger,
-		lookupCache:        make(map[string]*authData),
+		config:                cfg,
+		httpClientSettings:    cfg.ServerAuth.ClientConfig,
+		telemetrySettings:     params.TelemetrySettings,
+		logger:                params.Logger,
+		lookupCache:           make(map[string]*authData),
+		debugLogInvalidKeys:   strings.EqualFold(os.Getenv("CHQAUTH_SERVER_DEBUG"), "true"),
+		invalidKeyLogLastSeen: make(map[string]time.Time),
 	}
 	if err := chq.setupServerTelemetry(params); err != nil {
 		return nil, err
@@ -151,10 +160,27 @@ func (chq *chqServerAuth) setcache(ad *authData) {
 	chq.lookupCache[ad.apiKey] = ad
 }
 
+func (chq *chqServerAuth) maybeLogInvalidKey(apiKey string) {
+	if !chq.debugLogInvalidKeys {
+		return
+	}
+	chq.invalidKeyLogLock.Lock()
+	now := time.Now()
+	last, ok := chq.invalidKeyLogLastSeen[apiKey]
+	if ok && now.Sub(last) < invalidKeyLogInterval {
+		chq.invalidKeyLogLock.Unlock()
+		return
+	}
+	chq.invalidKeyLogLastSeen[apiKey] = now
+	chq.invalidKeyLogLock.Unlock()
+	chq.logger.Info("invalid API key attempted", zap.String("api_key", apiKey))
+}
+
 func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey string) (*authData, error) {
 	cached, expired := chq.getcache(apiKey)
 	if cached != nil && !expired {
 		if !cached.valid {
+			chq.maybeLogInvalidKey(apiKey)
 			return nil, errDenied
 		}
 		return cached, nil
@@ -168,6 +194,7 @@ func (chq *chqServerAuth) authenticateAPIKey(ctx context.Context, apiKey string)
 				valid:  false,
 				expiry: time.Now().Add(chq.config.ServerAuth.CacheTTLInvalid),
 			})
+			chq.maybeLogInvalidKey(apiKey)
 			// A definitive denial must never fall back to a previously
 			// cached valid entry — that would let a revoked key keep
 			// authenticating as its former customer for one more TTL

--- a/extension/chqauthextension/serverauth_test.go
+++ b/extension/chqauthextension/serverauth_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func newchq() *chqServerAuth {
@@ -36,10 +37,11 @@ func newchq() *chqServerAuth {
 	cam, _ := m.Int64Counter("auth_cache_adds")
 
 	chq := &chqServerAuth{
-		logger:           zap.NewNop(),
-		lookupCache:      make(map[string]*authData),
-		authCacheLookups: clm,
-		authCacheAdds:    cam,
+		logger:                zap.NewNop(),
+		lookupCache:           make(map[string]*authData),
+		authCacheLookups:      clm,
+		authCacheAdds:         cam,
+		invalidKeyLogLastSeen: make(map[string]time.Time),
 	}
 	return chq
 }
@@ -220,6 +222,7 @@ func TestGetAuthHeader(t *testing.T) {
 		})
 	}
 }
+
 // newchqWithServer returns a chqServerAuth wired against a mock validator
 // whose JSON body is controlled by the test. The returned cleanup closes
 // the server.
@@ -411,3 +414,59 @@ func TestAuthenticateAPIKey_TransientErrorFallsBackToCache(t *testing.T) {
 	assert.Equal(t, "cust-1", ad2.customerID)
 }
 
+func TestMaybeLogInvalidKey_RateLimited(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	chq := newchq()
+	chq.logger = zap.New(core)
+	chq.debugLogInvalidKeys = true
+
+	chq.maybeLogInvalidKey("secret-key")
+	chq.maybeLogInvalidKey("secret-key")
+	chq.maybeLogInvalidKey("other-key")
+
+	entries := logs.All()
+	require.Len(t, entries, 2)
+	for _, e := range entries {
+		assert.Equal(t, "invalid API key attempted", e.Message)
+	}
+	assert.Equal(t, "secret-key", entries[0].ContextMap()["api_key"])
+	assert.Equal(t, "other-key", entries[1].ContextMap()["api_key"])
+
+	// Simulate time passing beyond the rate-limit window.
+	chq.invalidKeyLogLastSeen["secret-key"] = time.Now().Add(-invalidKeyLogInterval - time.Second)
+	chq.maybeLogInvalidKey("secret-key")
+	assert.Len(t, logs.All(), 3)
+}
+
+func TestMaybeLogInvalidKey_DisabledByDefault(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	chq := newchq()
+	chq.logger = zap.New(core)
+	// debugLogInvalidKeys left false
+
+	chq.maybeLogInvalidKey("secret-key")
+	assert.Empty(t, logs.All())
+}
+
+func TestAuthenticateAPIKey_LogsFullInvalidKeyWhenDebugEnabled(t *testing.T) {
+	chq, srv := newchqWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	defer srv.Close()
+
+	core, logs := observer.New(zap.InfoLevel)
+	chq.logger = zap.New(core)
+	chq.debugLogInvalidKeys = true
+
+	_, err := chq.authenticateAPIKey(context.Background(), "bad-key")
+	assert.ErrorIs(t, err, errDenied)
+
+	// Second call within rate-limit window hits the negative cache; still
+	// should not produce a duplicate log entry.
+	_, err = chq.authenticateAPIKey(context.Background(), "bad-key")
+	assert.ErrorIs(t, err, errDenied)
+
+	entries := logs.FilterMessage("invalid API key attempted").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "bad-key", entries[0].ContextMap()["api_key"])
+}


### PR DESCRIPTION
## Summary
- Adds a debug mode to `chqauthextension`'s server auth: when `CHQAUTH_SERVER_DEBUG=true`, the full API key is logged on every authentication denial.
- Per-key rate-limited to at most one log line every 5 minutes, so repeated attempts with the same invalid key don't spam logs.
- Disabled by default; no change in behavior unless the env var is set.

## Test plan
- [x] `go test ./...` in `extension/chqauthextension`
- [x] New unit tests cover rate limiting, disabled-by-default, and end-to-end denial logging path (including the negative-cache short-circuit)