### PR TITLE
ci: native partial+merge release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,29 @@ on:
 permissions:
   id-token: write
   contents: write
-  # packages: write
-  # issues: write
 
 jobs:
-  goreleaser:
-    runs-on: linux-x64-4m-16gb-150ssd
+  partials:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux_amd64
+            label: ubuntu-22.04
+            cache_path: dist/linux_amd64
+          - name: linux_arm64
+            label: ubuntu-22.04-arm
+            cache_path: dist/linux_arm64
+    runs-on: ${{ matrix.label }}
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        # no cache here intentionally
-        id: go
         uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -32,8 +39,8 @@ jobs:
       - name: go-cache-paths
         id: go-cache-paths
         run: |
-          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
       - name: Go Build Cache
         uses: actions/cache@v4
@@ -41,16 +48,10 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-${{ runner.arch }}-go-build
 
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
-        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           audience: sts.amazonaws.com
@@ -59,22 +60,139 @@ jobs:
           role-session-name: GitHubActions
 
       - name: Login to PUBLIC Amazon ECR
-        id: login-ecr-public
         env:
           AWS_REGION: us-east-1
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
 
+      - name: sha_short
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Cache partial dist
+        uses: actions/cache@v4
+        with:
+          path: ${{ matrix.cache_path }}
+          key: ${{ matrix.name }}-${{ env.sha_short }}
+
       - name: make clean
         run: make clean
 
-      - name: Run GoReleaser
-        id: goreleaser
+      - name: Setup GoReleaser Pro
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
-          version: "nightly"
-          args: release --clean -f .goreleaser-release.yaml
+          distribution: goreleaser-pro
+          version: "~> v2"
+          install-only: true
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Run GoReleaser Pro split
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goreleaser release --clean --split -f .goreleaser-release.yaml
+
+  merge:
+    needs: partials
+    runs-on: ubuntu-22.04
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          audience: sts.amazonaws.com
+          role-to-assume: arn:aws:iam::${{ secrets.ECR_ACCOUNT_ID }}:role/${{ secrets.ECR_ROLE_NAME }}
+          aws-region: ${{ secrets.ECR_REGISTRY_REGION }}
+          role-session-name: GitHubActions
+
+      - name: Login to PUBLIC Amazon ECR
+        env:
+          AWS_REGION: us-east-1
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: sha_short
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Restore amd64 partial
+        uses: actions/cache@v4
+        with:
+          path: dist/linux_amd64
+          key: linux_amd64-${{ env.sha_short }}
+          fail-on-cache-miss: true
+
+      - name: Restore arm64 partial
+        uses: actions/cache@v4
+        with:
+          path: dist/linux_arm64
+          key: linux_arm64-${{ env.sha_short }}
+          fail-on-cache-miss: true
+
+      - name: Setup GoReleaser Pro
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          version: "~> v2"
+          install-only: true
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Run GoReleaser Pro merge
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+        run: goreleaser continue --merge
+
+  release:
+    needs: merge
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; skipping creation."
+            exit 0
+          fi
+
+          LAST_RELEASE=$(gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --exclude-pre-releases \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName' || echo "")
+
+          if [ -n "$LAST_RELEASE" ]; then
+            RELEASE_NOTES="## Changes since ${LAST_RELEASE}"$'\n\n'
+            RELEASE_NOTES+=$(git log --oneline "${LAST_RELEASE}..HEAD" --no-merges | sed 's/^/* /')
+          else
+            RELEASE_NOTES="## Changes"$'\n\n'
+            RELEASE_NOTES+=$(git log --oneline --no-merges | head -10 | sed 's/^/* /')
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Release $RELEASE_TAG" \
+            --notes "$RELEASE_NOTES" \
+            --latest

--- a/.goreleaser-release.yaml
+++ b/.goreleaser-release.yaml
@@ -1,5 +1,9 @@
 project_name: cardinalhq-otel-collector
 version: 2
+
+partial:
+  by: target
+
 builds:
   - id: cardinalhq-otel-collector
     goos:
@@ -20,10 +24,9 @@ builds:
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 release:
-  draft: false
-  prerelease: auto
+  disable: true
 changelog:
-  sort: asc
+  disable: true
 archives:
   - id: default
     # use the "binary" format so GoReleaser skips creating an archive


### PR DESCRIPTION
## Summary
- Replace single-runner QEMU-based release build with parallel native partial builds (`ubuntu-22.04` for amd64, `ubuntu-22.04-arm` for arm64) using GoReleaser Pro `--split`
- New `merge` job assembles the multi-arch manifest via `goreleaser continue --merge`
- New `release` job creates the GitHub Release via `gh release create`
- Trigger unchanged (`push: tags: v*`), so PRs cannot run this

## Why
The previous single-runner build was using QEMU to emulate arm64 and was hanging at the GoReleaser step (twice on v1.8.0, runner died after ~52 min with no log output). Native per-arch runners are faster and more reliable.

## Notes
- Requires `GORELEASER_KEY` secret (already configured per the lakerunner workflow that uses the same pattern).
- `release` and `changelog` are disabled in `.goreleaser-release.yaml`; release creation moved to `gh release create` with auto-generated notes from `git log` since the previous tag.

## Test plan
- [ ] Merge this PR
- [ ] Re-tag v1.8.0 from main HEAD
- [ ] Confirm partials + merge + release jobs succeed