### PR TITLE
ci: drop dummy GITHUB_TOKEN from snapshot build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,4 +45,4 @@ jobs:
           version: "nightly"
           args: release --clean --snapshot -f .goreleaser-buildonly.yaml
         env:
-          GITHUB_TOKEN: dummy
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #312. goreleaser-action@v7 authenticates against the GitHub API to resolve version: nightly, and a placeholder GITHUB_TOKEN: dummy now returns 401. Pass the default token through.