### PR TITLE
ci: woodpecker make check (non-required)

### DIFF
--- a/.woodpecker/check.yaml
+++ b/.woodpecker/check.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024-2026 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Woodpecker pipeline: run `make check` (test + license-check + lint) for the
+# whole monorepo on the kubepi cluster, with durable Go caches so the cold
+# ~1h `make check` becomes minutes on warm runs.
+#
+# The filename is the workflow name, so this reports to GitHub as commit status
+# `ci/woodpecker/push/check`. It is intentionally NON-REQUIRED: do not add
+# `ci/woodpecker/*` to main's branch-protection required contexts. It shows up
+# on PRs (via the branch push) as an informational status, in parallel with the
+# GitHub Actions build.
+#
+# Uses the org-level `github_token` secret (cardinalhq org) to fetch the
+# private cardinalhq/oteltools modules over HTTPS. The secret is server-side
+# restricted to non-PR events.
+#
+# Durable shared caches (ci-gomodcache, ci-gobuildcache) are Argo-managed
+# cluster infra, NOT defined in this repo. Source of truth:
+#   skandragon/kubernetes-clusters: clusters/kubepi/woodpecker/cache-pvcs.yaml
+#
+# SECURITY: pull_request is intentionally NOT a trigger. This build injects a
+# token and writes to shared RWX caches; running it on untrusted PR-controlled
+# code/config would be a pwn-request + cache-poisoning vector. Only pushed
+# (trusted) commits run here.
+
+when:
+  - event: [push, manual]
+
+steps:
+  - name: check
+    image: docker.io/golang:1.26-bookworm
+    pull: true
+    # Durable shared caches on proxmox-cephfs (RWX). Syntax: {pvc-name}:{mount-path}.
+    volumes:
+      - ci-gomodcache:/cache/gomod      # GOMODCACHE
+      - ci-gobuildcache:/cache/go-build # GOCACHE + golangci-lint cache (biggest lever)
+    environment:
+      GOMODCACHE: /cache/gomod
+      GOCACHE: /cache/go-build
+      GOLANGCI_LINT_CACHE: /cache/go-build/golangci-lint
+      GOPRIVATE: github.com/cardinalhq/*
+      # Single token covers private cardinalhq/* Go module fetches.
+      GH_TOKEN:
+        from_secret: github_token
+    commands:
+      # Authenticate private cardinalhq/* Go modules over HTTPS. Scope the
+      # credential to cardinalhq only so the token is never sent elsewhere.
+      - git config --global url."https://x-access-token:$${GH_TOKEN}@github.com/cardinalhq/".insteadOf "https://github.com/cardinalhq/"
+      - git config --global --add safe.directory '*'
+      - go version
+      # test + license-check + lint across all modules. The lint/license targets
+      # install pinned dev tools (golangci-lint, license-eye) via `go install`.
+      - make check

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# MODULE_SOURCE_PATHS (below) uses brace expansion, which dash/POSIX sh does
+# not support. Force bash so module discovery works on any host (e.g. CI's
+# golang container, where /bin/sh is dash) -- not just shells that happen to
+# expand braces.
+SHELL := /bin/bash
+
 TARGETS=bin/cardinalhq-otel-collector
 OTEL_VERSION=v0.153.0
 


### PR DESCRIPTION
Add a Woodpecker pipeline that runs `make check` (test + license-check + lint) for the whole monorepo on kubepi, with durable shared Go caches so the cold ~1h check becomes minutes on warm runs.

- `event: [push, manual]` (never pull_request — pwn-request safety). Reports to GitHub as the **non-required** status `ci/woodpecker/push/check`; not added to branch-protection.
- Uses the org-level `github_token` for private `cardinalhq/oteltools` modules (no repo secret needed).
- Mounts the Argo-managed shared caches `ci-gomodcache`/`ci-gobuildcache` (defined in skandragon/kubernetes-clusters).

First run is cold (~1h, fills the cache); subsequent runs are minutes.