### PR TITLE
ci: use woodpecker-builder image with prebuilt go

### DIFF
--- a/.woodpecker/check.yaml
+++ b/.woodpecker/check.yaml
@@ -40,7 +40,7 @@ when:
 
 steps:
   - name: check
-    image: docker.io/golang:1.26-bookworm
+    image: docker.flame.org/library/woodpecker-builder:stable
     pull: true
     # Durable shared caches on proxmox-cephfs (RWX). Syntax: {pvc-name}:{mount-path}.
     volumes:


### PR DESCRIPTION
Swaps the `check` step base image from `docker.io/golang:1.26-bookworm` to `docker.flame.org/library/woodpecker-builder:stable`, which ships Go pre-installed.

Cache mounts and env (`GOMODCACHE`, `GOCACHE`, `GOLANGCI_LINT_CACHE`) are unchanged and still override the image defaults, so warm-cache behavior is preserved.