### PR TITLE
ci: build multi-arch image on woodpecker, copy to ECR

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,5 +1,14 @@
 name: goreleaser-latest-dev
 
+# Publishes the dev image at public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:<tag>.
+#
+# MODE = vars.IMAGE_BUILD_SOURCE (default 'woodpecker'):
+#   woodpecker -> wait for the kubepi Woodpecker build (ci/woodpecker/push/image)
+#                 and copy its multi-arch image from Harbor (docker.flame.org) to
+#                 ECR (no rebuild; reuses kubepi's warm build cache).
+#   gha        -> cross-compile + build the image here and push (fallback /
+#                 swap-back if kubepi is unavailable).
+
 on:
   push:
     tags:
@@ -8,45 +17,18 @@ on:
 permissions:
   id-token: write
   contents: write
-  # packages: write
-  # issues: write
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      MODE: ${{ vars.IMAGE_BUILD_SOURCE || 'woodpecker' }}
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Set up Go
-        # no cache here intentionally
-        id: go
-        uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - name: go-cache-paths
-        id: go-cache-paths
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      - name: Go Build Cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-${{ runner.arch }}-go-build
-
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v4
 
       - name: Configure AWS credentials
         id: aws-credentials
@@ -65,7 +47,75 @@ jobs:
         with:
           registry-type: public
 
+      # ---- woodpecker mode: wait for the kubepi build, then copy ----
+      - name: Wait for Woodpecker image build
+        if: ${{ env.MODE == 'woodpecker' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ctx="ci/woodpecker/push/image"
+          deadline=$(( $(date +%s) + 1500 ))   # 25 min
+          while :; do
+            state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/statuses" \
+              --jq "[.[] | select(.context == \"$ctx\")][0].state // \"\"")
+            case "$state" in
+              success) echo "Woodpecker image build succeeded"; break ;;
+              failure|error) echo "::error::Woodpecker image build $state. Set repo variable IMAGE_BUILD_SOURCE=gha to build in Actions."; exit 1 ;;
+              *) : ;;  # absent or pending
+            esac
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for $ctx on $GITHUB_SHA. Set IMAGE_BUILD_SOURCE=gha to build in Actions."; exit 1
+            fi
+            echo "waiting for $ctx (state='${state:-absent}')..."
+            sleep 15
+          done
+
+      - name: Set up Docker Buildx
+        if: ${{ env.MODE == 'woodpecker' }}
+        uses: docker/setup-buildx-action@v4
+
+      - name: Copy image from Woodpecker (Harbor) to ECR
+        if: ${{ env.MODE == 'woodpecker' }}
+        run: |
+          docker buildx imagetools create \
+            -t "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:${GITHUB_REF_NAME}" \
+            "docker.flame.org/library/cardinalhq-otel-collector:${GITHUB_REF_NAME}"
+
+      # ---- gha mode: cross-compile both arches here and push ----
+      - name: Set up Go
+        if: ${{ env.MODE == 'gha' }}
+        # no cache here intentionally
+        id: go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: go-cache-paths
+        if: ${{ env.MODE == 'gha' }}
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      - name: Go Build Cache
+        if: ${{ env.MODE == 'gha' }}
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-${{ runner.arch }}-go-build
+
+      - name: Set up QEMU
+        if: ${{ env.MODE == 'gha' }}
+        id: qemu
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx (gha)
+        if: ${{ env.MODE == 'gha' }}
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Run GoReleaser
+        if: ${{ env.MODE == 'gha' }}
         id: goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.cross.yaml
+++ b/.goreleaser.cross.yaml
@@ -1,0 +1,59 @@
+# Copyright 2024-2026 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Builds-only goreleaser config for the single-host cross-compile image builds,
+# shared by the kubepi Woodpecker pipeline (.woodpecker/image.yaml) and the
+# GitHub Actions gha-mode fallback (.github/workflows/dev.yml). It cross-builds
+# the Go binary for both arches on a single amd64 node; the multi-arch image
+# itself is assembled and pushed by buildx against Dockerfile.cross, NOT by
+# goreleaser -- so there is no `dockers:` / `docker_manifests:` section here.
+#
+# The collector is pure Go with CGO_ENABLED=0, so the arm64 binary
+# cross-compiles natively with no cross toolchain and no QEMU.
+#
+# Version comes from $IMAGE_VERSION (the tag computed in the pipeline and
+# written to .tags), since dev-branch commits have no git tag.
+
+version: 2
+
+project_name: cardinalhq-otel-collector
+
+snapshot:
+  version_template: "{{ .Env.IMAGE_VERSION }}"
+
+checksum:
+  disable: true
+
+release:
+  disable: true
+
+changelog:
+  disable: true
+
+builds:
+  - id: cardinalhq-otel-collector
+    dir: distribution
+    binary: cardinalhq-otel-collector
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+    env:
+      - CGO_ENABLED=0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -13,6 +13,7 @@ header:
     - 'LICENSE'
     - 'NOTICE'
     - .gitignore
+    - '**/*.dockerignore'
     - .dockerignore
     - .helmignore
     - .github

--- a/.woodpecker/image.yaml
+++ b/.woodpecker/image.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2026 CardinalHQ, Inc
+# Copyright 2024-2025 CardinalHQ, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,25 +17,36 @@
 # image to docker.flame.org/library/cardinalhq-otel-collector. The GitHub
 # Actions publish workflow (.github/workflows/dev.yml) waits for this build's
 # `ci/woodpecker/push/image` status and then copies the image to its publish
-# target (public.ecr.aws) instead of rebuilding -- this is the source of the
-# build cache. docker.flame.org is the only registry this pipeline pushes to.
+# target (public.ecr.aws) instead of rebuilding. docker.flame.org is the only
+# registry this pipeline pushes to.
 #
-# The collector is pure Go (CGO_ENABLED=0), so goreleaser cross-builds both
-# arches natively on the amd64 host with no cross toolchain. Dockerfile.cross
-# only COPYs the prebuilt per-arch binary, so even the arm64 image assembles in
-# seconds with no QEMU emulation.
+# Two stages, two engines:
 #
-# Engine: woodpeckerci/plugin-docker-buildx (privileged, server-allowlisted).
-# It stands up its own buildkit + QEMU per run; here QEMU only covers the
-# trivial COPY layers, not any per-arch compile.
+#   1. build-binary (woodpecker-builder:stable, amd64): the collector is pure Go
+#      (CGO_ENABLED=0), so goreleaser cross-builds BOTH arches natively on this
+#      amd64 node -- no cross toolchain, and crucially no emulation of the heavy
+#      Go compile. Shares the durable ci-gomodcache/ci-gobuildcache PVCs with
+#      check.yaml.
 #
-# SECURITY: pull_request is intentionally NOT a trigger. This build is
-# privileged and injects github_token + Harbor push creds; running it on
-# untrusted PR-controlled code would be a pwn-request vector. Only pushed
-# (trusted) commits run here, consistent with check.yaml. Reports to GitHub as
-# ci/woodpecker/push/image; intentionally NOT a required check.
+#   2. publish: assemble + push the multi-arch image on the shared,
+#      argocd-managed kubepi0 buildkitd (ns `buildkit`) as a REMOTE builder over
+#      kube-pod://, using Dockerfile.cross. kubepi0 is an amd64 host with
+#      binfmt/QEMU registered, so it CAN build linux/arm64 -- it just emulates
+#      it. Here that costs almost nothing: Dockerfile.cross compiles nothing
+#      per-arch (the binary is prebuilt and COPYed), so the only emulated arm64
+#      work is the tiny apt/ldd `tools` stage, and kubepi0's persistent
+#      /var/lib/buildkit cache PVC keeps even that warm across runs. Using
+#      kubepi0 (vs. an ephemeral in-pod buildkit) means no per-run buildkit
+#      startup and a shared warm layer cache. Requires the buildkit-client
+#      SA/RBAC on the cluster.
 #
-# Requires Woodpecker secrets:
+# SECURITY: pull_request is intentionally NOT a trigger. This injects a
+# github_token + Harbor push creds; running it on untrusted PR-controlled code
+# would be a pwn-request vector. Only pushed (trusted) commits run here,
+# consistent with check.yaml. Reports to GitHub as ci/woodpecker/push/image;
+# intentionally NOT a required check.
+#
+# Requires Woodpecker secrets (org-level):
 #   - github_token                 (private cardinalhq/* modules, gh pr list)
 #   - docker_flame_org_username    (Harbor robot for project library)
 #   - docker_flame_org_password
@@ -71,7 +82,7 @@ steps:
 
       - go version && goreleaser --version
 
-      # --- compute the image tag -> .tags (read automatically by the buildx plugin) ---
+      # --- compute the image tag -> .tags ---
       # Tag events use the git tag verbatim (v1.2.3, v1.2.3-rc1); GHA copies that
       # exact tag from Harbor to ECR. Branch builds keep the v0.0.0-pr<N> /
       # v0.0.0-<branch> scheme.
@@ -102,15 +113,48 @@ steps:
       - ls -l docker/bin/linux_amd64 docker/bin/linux_arm64
 
   - name: publish
-    image: woodpeckerci/plugin-docker-buildx
-    settings:
-      repo: docker.flame.org/library/cardinalhq-otel-collector
-      registry: docker.flame.org
-      dockerfile: Dockerfile.cross
-      platforms: linux/amd64,linux/arm64
-      ipv6: true
-      buildkit_driveropt: network=host
-      username:
+    # buildctl client; talks to the kubepi0 buildkitd over kube-pod://.
+    image: moby/buildkit:buildx-stable-1
+    pull: true
+    # SA allowed to reach kubepi0 via kube-pod:// (in-cluster creds auto-mounted;
+    # buildctl's kube-pod connhelper uses them).
+    backend_options:
+      kubernetes:
+        serviceAccountName: buildkit-client
+    environment:
+      FLAME_USER:
         from_secret: docker_flame_org_username
-      password:
+      FLAME_PASS:
         from_secret: docker_flame_org_password
+    commands:
+      # kube-pod:// connhelper shells out to `kubectl exec`, so kubectl must exist.
+      - apk add --no-cache curl jq
+      - curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      - chmod +x /usr/local/bin/kubectl
+      # --- registry auth for the push (buildctl reads DOCKER_CONFIG) ---
+      - |
+        mkdir -p /root/.docker
+        auth=$$(printf '%s:%s' "$${FLAME_USER}" "$${FLAME_PASS}" | base64 | tr -d '\n')
+        printf '{"auths":{"docker.flame.org":{"auth":"%s"}}}' "$$auth" > /root/.docker/config.json
+      # --- resolve the running kubepi0 pod (kube-pod:// needs a concrete pod) ---
+      - |
+        APISERVER=https://kubernetes.default.svc
+        SA=/var/run/secrets/kubernetes.io/serviceaccount
+        POD=$$(curl -fsSL --cacert $$SA/ca.crt -H "Authorization: Bearer $$(cat $$SA/token)" \
+          "$$APISERVER/api/v1/namespaces/buildkit/pods?labelSelector=app%3Dkubepi0" \
+          | jq -r '.items[] | select(.status.phase=="Running") | .metadata.name' | head -n1)
+        echo "buildkit pod = $$POD"
+        echo "$$POD" > .bk-pod
+      # --- build Dockerfile.cross on kubepi0 and push the multi-arch index ---
+      # Warm layer cache lives on kubepi0's /var/lib/buildkit PVC. Context is
+      # trimmed to docker/ by Dockerfile.cross.dockerignore (just the prebuilt
+      # per-arch binaries), so the kube-pod:// stream stays small.
+      - |
+        buildctl --addr "kube-pod://$$(cat .bk-pod)?namespace=buildkit" \
+          build \
+          --frontend dockerfile.v0 \
+          --local context=. \
+          --local dockerfile=. \
+          --opt filename=Dockerfile.cross \
+          --opt platform=linux/amd64,linux/arm64 \
+          --output type=image,name=docker.flame.org/library/cardinalhq-otel-collector:$$(cat .tags),push=true

--- a/.woodpecker/image.yaml
+++ b/.woodpecker/image.yaml
@@ -1,0 +1,116 @@
+# Copyright 2024-2026 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Woodpecker pipeline: build the cardinalhq-otel-collector container image for
+# dev-branch commits AND for release tags, pushing the multi-arch (amd64+arm64)
+# image to docker.flame.org/library/cardinalhq-otel-collector. The GitHub
+# Actions publish workflow (.github/workflows/dev.yml) waits for this build's
+# `ci/woodpecker/push/image` status and then copies the image to its publish
+# target (public.ecr.aws) instead of rebuilding -- this is the source of the
+# build cache. docker.flame.org is the only registry this pipeline pushes to.
+#
+# The collector is pure Go (CGO_ENABLED=0), so goreleaser cross-builds both
+# arches natively on the amd64 host with no cross toolchain. Dockerfile.cross
+# only COPYs the prebuilt per-arch binary, so even the arm64 image assembles in
+# seconds with no QEMU emulation.
+#
+# Engine: woodpeckerci/plugin-docker-buildx (privileged, server-allowlisted).
+# It stands up its own buildkit + QEMU per run; here QEMU only covers the
+# trivial COPY layers, not any per-arch compile.
+#
+# SECURITY: pull_request is intentionally NOT a trigger. This build is
+# privileged and injects github_token + Harbor push creds; running it on
+# untrusted PR-controlled code would be a pwn-request vector. Only pushed
+# (trusted) commits run here, consistent with check.yaml. Reports to GitHub as
+# ci/woodpecker/push/image; intentionally NOT a required check.
+#
+# Requires Woodpecker secrets:
+#   - github_token                 (private cardinalhq/* modules, gh pr list)
+#   - docker_flame_org_username    (Harbor robot for project library)
+#   - docker_flame_org_password
+# and the durable RWX caches ci-gomodcache, ci-gobuildcache (shared with
+# check.yaml).
+
+when:
+  - event: [push, manual]
+    branch:
+      exclude: [main]
+  # Release/RC tag pushes (v1.2.3, v1.2.3-rc1, ...). The branch filter above does
+  # not apply to tag events, so they are not excluded by it.
+  - event: tag
+
+steps:
+  - name: build-binary
+    # Shared CI builder: golang + goreleaser/gh prebaked. Auto-refreshes daily.
+    image: docker.flame.org/library/woodpecker-builder:stable
+    pull: true
+    volumes:
+      - ci-gomodcache:/cache/gomod      # GOMODCACHE
+      - ci-gobuildcache:/cache/go-build # GOCACHE
+    environment:
+      GOMODCACHE: /cache/gomod
+      GOCACHE: /cache/go-build
+      GOPRIVATE: github.com/cardinalhq/*
+      GH_TOKEN:
+        from_secret: github_token
+    commands:
+      # --- private cardinalhq/* Go modules over HTTPS (scoped to cardinalhq) ---
+      - git config --global url."https://x-access-token:$${GH_TOKEN}@github.com/cardinalhq/".insteadOf "https://github.com/cardinalhq/"
+      - git config --global --add safe.directory '*'
+
+      - go version && goreleaser --version
+
+      # --- compute the image tag -> .tags (read automatically by the buildx plugin) ---
+      # Tag events use the git tag verbatim (v1.2.3, v1.2.3-rc1); GHA copies that
+      # exact tag from Harbor to ECR. Branch builds keep the v0.0.0-pr<N> /
+      # v0.0.0-<branch> scheme.
+      - |
+        if [ -n "$$CI_COMMIT_TAG" ]; then
+          echo "$$CI_COMMIT_TAG" > .tags
+        else
+          sha8=$$(git rev-parse --short=8 HEAD)
+          PRNUM=$$(gh pr list --repo "$$CI_REPO" --head "$$CI_COMMIT_BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$$PRNUM" ] && [ "$$PRNUM" != "null" ]; then
+            echo "v0.0.0-pr$${PRNUM}-$${sha8}" > .tags
+          else
+            echo "v0.0.0-$$(echo "$$CI_COMMIT_BRANCH" | tr '/' '-')-$${sha8}" > .tags
+          fi
+        fi
+      - export IMAGE_VERSION=$$(cat .tags)
+      - echo "Building image tag $${IMAGE_VERSION}"
+
+      # --- cross-build the Go binary for both arches (no QEMU, no CGO) ---
+      - goreleaser build --snapshot --clean --config .goreleaser.cross.yaml
+
+      # --- stage the per-arch binary where Dockerfile.cross copies it ---
+      - |
+        for arch in amd64 arm64; do
+          mkdir -p docker/bin/linux_$$arch
+          cp dist/cardinalhq-otel-collector_linux_$${arch}*/cardinalhq-otel-collector docker/bin/linux_$$arch/cardinalhq-otel-collector
+        done
+      - ls -l docker/bin/linux_amd64 docker/bin/linux_arm64
+
+  - name: publish
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: docker.flame.org/library/cardinalhq-otel-collector
+      registry: docker.flame.org
+      dockerfile: Dockerfile.cross
+      platforms: linux/amd64,linux/arm64
+      ipv6: true
+      buildkit_driveropt: network=host
+      username:
+        from_secret: docker_flame_org_username
+      password:
+        from_secret: docker_flame_org_password

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,58 @@
+# Copyright 2024-2026 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Cross-compile image build, shared by the kubepi Woodpecker pipeline
+# (.woodpecker/image.yaml, via woodpeckerci/plugin-docker-buildx) and the GitHub
+# Actions gha-mode fallback (.github/workflows/dev.yml, via buildx).
+# Context = repo root.
+#
+# Unlike ./Dockerfile, this variant compiles NOTHING per-arch: the Go binary is
+# cross-built on the amd64 host in the build-binaries step and staged into
+# docker/bin/linux_${TARGETARCH}/. Nothing is emulated per-arch beyond the
+# trivial COPY layers, so the arm64 image assembles in seconds.
+
+ARG TARGETARCH
+
+FROM debian:12-slim AS tools
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
+# Use ldd to find curl dependencies and copy them to staging directory
+RUN mkdir -p /tmp/curl-deps && \
+    ldd /usr/bin/curl | grep "=> /" | awk '{print $3}' | xargs -I {} cp {} /tmp/curl-deps/ 2>/dev/null || true
+
+FROM public.ecr.aws/cardinalhq.io/geoip-base:latest AS geoip
+
+FROM gcr.io/distroless/base-debian12:debug
+
+ARG TARGETARCH
+
+COPY --from=tools /usr/bin/curl /usr/bin/curl
+# Copy all curl dependencies discovered dynamically
+COPY --from=tools /tmp/curl-deps/ /lib/
+COPY --from=tools /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+COPY --from=geoip /app/geoip /app/geoip
+# Pre-built per-arch by the build-binaries step.
+COPY --chmod=755 docker/bin/linux_${TARGETARCH}/cardinalhq-otel-collector /app/bin/cardinalhq-otel-collector
+COPY --chmod=755 docker/run-with-env-config.sh /app/bin/run-with-env-config
+
+ARG USER_UID=2000
+USER ${USER_UID}:${USER_UID}
+
+# The base image has the geoip database in /app/geoip
+ENV GEOIP_DB_PATH=/app/geoip/GeoLite2-City.mmdb
+
+# Remove the distroless entrypoint so we can use our own
+ENTRYPOINT []
+CMD ["/app/bin/cardinalhq-otel-collector", "--config", "/app/config/config.yaml"]
+EXPOSE 4317 55678 55679

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,4 +1,4 @@
-# Copyright 2024-2026 CardinalHQ, Inc
+# Copyright 2024-2025 CardinalHQ, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile.cross.dockerignore
+++ b/Dockerfile.cross.dockerignore
@@ -1,0 +1,6 @@
+# Context shipped to the remote kubepi0 buildkitd for Dockerfile.cross is only
+# the prebuilt per-arch binaries + the docker/ helpers. Everything else (source
+# tree, goreleaser dist/, etc.) is excluded so the kube-pod:// context stream
+# stays small.
+*
+!docker


### PR DESCRIPTION
Mirrors the lakerunner build pattern: build the multi-arch collector image on the kubepi Woodpecker cluster and have GitHub Actions copy it instead of rebuilding. Because the collector is pure Go (\`CGO_ENABLED=0\`), cross-compiling amd64+arm64 needs no cross toolchain and no QEMU per-arch compile.

## New files
- **\`.goreleaser.cross.yaml\`** — builds-only config; cross-builds the Go binary for both arches on one amd64 host. Version from \`\$IMAGE_VERSION\`.
- **\`Dockerfile.cross\`** — same runtime as \`Dockerfile\` but \`COPY\`s a prebuilt per-arch binary from \`docker/bin/linux_\${TARGETARCH}/\`, so the arm64 image assembles in seconds with no emulation.
- **\`.woodpecker/image.yaml\`** — on branch push (excl. main) + tags: cross-build the binary, then push the multi-arch image to \`docker.flame.org/library/cardinalhq-otel-collector\` via \`plugin-docker-buildx\`. Reports as \`ci/woodpecker/push/image\` (non-required). Same no-\`pull_request\` security posture and shared \`ci-gomodcache\`/\`ci-gobuildcache\` PVCs as \`check.yaml\`.

## Changed
- **\`.github/workflows/dev.yml\`** — adds \`MODE = vars.IMAGE_BUILD_SOURCE || 'woodpecker'\`:
  - **woodpecker** (default): wait for \`ci/woodpecker/push/image\`, then \`docker buildx imagetools create\` to copy flame.org → \`public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:<tag>\`. No rebuild.
  - **gha**: existing goreleaser release path (fallback if kubepi is unavailable).

## Requires (Woodpecker secrets, same as lakerunner)
\`github_token\`, \`docker_flame_org_username\`, \`docker_flame_org_password\`.

\`goreleaser check\` passes on the new config; the cross-build itself runs in CI.